### PR TITLE
feat: oauth2-proxy

### DIFF
--- a/charts/keep/Chart.yaml
+++ b/charts/keep/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: keep
-version: 0.1.6
+version: 0.1.7
 description: Keep Helm Chart
 type: application
 icon: https://platform.keephq.dev/_next/image?url=%2Fkeep.png&w=48&q=75

--- a/charts/keep/Chart.yaml
+++ b/charts/keep/Chart.yaml
@@ -4,7 +4,7 @@ version: 0.1.7
 description: Keep Helm Chart
 type: application
 icon: https://platform.keephq.dev/_next/image?url=%2Fkeep.png&w=48&q=75
-appVersion: 0.21.0
+appVersion: 0.23.0
 deprecated: false
 annotations:
   app: keep

--- a/charts/keep/templates/frontend-ingress.yaml
+++ b/charts/keep/templates/frontend-ingress.yaml
@@ -58,7 +58,7 @@ spec:
               {{- end }}
           {{- end }}
     {{- end }}
-  {{- if .Values.frontend.extraIngress }}
+  {{- if .Values.frontend.extraIngress -}}
   {{ toYaml .Values.frontend.extraIngress | nindent 2 }}
   {{- end }}
 {{- end }}

--- a/charts/keep/templates/frontend-ingress.yaml
+++ b/charts/keep/templates/frontend-ingress.yaml
@@ -58,4 +58,7 @@ spec:
               {{- end }}
           {{- end }}
     {{- end }}
+  {{- if .Values.frontend.extraIngress }}
+  {{ toYaml .Values.frontend.extraIngress | nindent 2 }}
+  {{- end }}
 {{- end }}

--- a/charts/keep/templates/keep-frontend-service.yaml
+++ b/charts/keep/templates/keep-frontend-service.yaml
@@ -16,6 +16,9 @@ spec:
       {{ if eq .Values.frontend.service.type "NodePort" }}
       nodePort: {{ .Values.frontend.service.nodePort }}
       {{- end }}
+    {{- if .Values.frontend.extraPorts }}
+    {{- toYaml .Values.frontend.extraPorts | nindent 4 }}
+    {{- end }}
   selector:
     {{- include "keep.selectorLabels" . | nindent 4 }}
     keep-component: frontend

--- a/charts/keep/templates/keep-frontend.yaml
+++ b/charts/keep/templates/keep-frontend.yaml
@@ -55,8 +55,8 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.frontend.resources | nindent 12 }}
-      {{- if .Values.frontend.extraContainers }}
-      {{ toYaml .Values.frontend.extraContainers | nindent 6 }}
+      {{- if .Values.frontend.extraContainers -}}
+      {{ toYaml .Values.frontend.extraContainers | nindent 8 }}
       {{- end }}
       {{- with .Values.frontend.nodeSelector }}
       nodeSelector:

--- a/charts/keep/templates/keep-frontend.yaml
+++ b/charts/keep/templates/keep-frontend.yaml
@@ -55,6 +55,9 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.frontend.resources | nindent 12 }}
+      {{- if .Values.frontend.extraContainers }}
+      {{ toYaml .Values.frontend.extraContainers | nindent 6 }}
+      {{- end }}
       {{- with .Values.frontend.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
```
frontend:
  extraContainers:
    - name: oauth2-proxy
      image: quay.io/oauth2-proxy/oauth2-proxy:latest
      # ... other oauth2-proxy configuration ...

  extraPorts:
    - port: 4180
      targetPort: 4180
      protocol: TCP
      name: oauth2-proxy

  extraIngress:
    # ... additional ingress configuration for oauth2-proxy ...
```