### PR TITLE
feat: enable extra volume mounts for front end

### DIFF
--- a/charts/keep/templates/frontend.yaml
+++ b/charts/keep/templates/frontend.yaml
@@ -91,6 +91,9 @@ spec:
             - name: state-volume
               mountPath: /state
               readOnly: false
+            {{- with .Values.frontend.extraVolumeMounts }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- if .Values.frontend.healthCheck.enabled }}
           {{- toYaml .Values.frontend.healthCheck.probes | nindent 10 }}
           {{- end }}
@@ -118,4 +121,7 @@ spec:
       volumes:
         - name: state-volume
           emptyDir: {}
+        {{- with .Values.frontend.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
 {{- end }}


### PR DESCRIPTION
This allows adding icons to generic events, e.g. add:

```
  extraVolumeMounts:
    - mountPath: /app/public/icons/eventc-icon.png 
      name: icons 
     subPath: eventc-icon.png 
  extraVolumes:
    - name: icons
      configMap: 
       name: icons
  
```

to the frontend section (and make a config map with your icon).

I added the icon config map via kustomize:

    configMapGenerator:
      - name: icons files: - eventc-icon.png

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
