### PR TITLE
feat: default backend healthcheck + using httpGet checks instead of tcpSocket + enabling healthCheck for backend by default

### DIFF
--- a/charts/keep/README.md
+++ b/charts/keep/README.md
@@ -66,11 +66,19 @@ Keep Helm Chart
 | backend.extraInitContainers | list | `[]` |  |
 | backend.extraVolumeMounts | list | `[]` |  |
 | backend.extraVolumes | list | `[]` |  |
-| backend.healthCheck.enabled | bool | `false` |  |
-| backend.healthCheck.probes.livenessProbe.tcpSocket.port | int | `8080` |  |
-| backend.healthCheck.probes.readinessProbe.initialDelaySeconds | int | `30` |  |
-| backend.healthCheck.probes.readinessProbe.periodSeconds | int | `10` |  |
-| backend.healthCheck.probes.readinessProbe.tcpSocket.port | int | `8080` |  |
+| backend.healthCheck.enabled | bool | `true` |  |
+| backend.healthCheck.probes.livenessProbe.httpGet.path | string | `/healthcheck	` |  |
+| backend.healthCheck.probes.livenessProbe.httpGet.port | int | `8080` |  |
+| backend.healthCheck.probes.livenessProbe.initialDelaySeconds | int | `60` |  |
+| backend.healthCheck.probes.livenessProbe.periodSeconds | int | `10` |  |
+| backend.healthCheck.probes.livenessProbe.failureThreshold | int | `5` |  |
+| backend.healthCheck.probes.livenessProbe.successThreshold | int | `1` |  |
+| backend.healthCheck.probes.readinessProbe.httpGet.path | string | `/healthcheck	` |  |
+| backend.healthCheck.probes.readinessProbe.httpGet.port | int | `8080` |  |
+| backend.healthCheck.probes.readinessProbe.initialDelaySeconds | int | `10` |  |
+| backend.healthCheck.probes.readinessProbe.periodSeconds | int | `5` |  |
+| backend.healthCheck.probes.readinessProbe.failureThreshold | int | `3` |  |
+| backend.healthCheck.probes.readinessProbe.successThreshold | int | `1` |  |
 | backend.image.pullPolicy | string | `"Always"` |  |
 | backend.image.repository | string | `"us-central1-docker.pkg.dev/keephq/keep/keep-api"` |  |
 | backend.imagePullSecrets | list | `[]` |  |

--- a/charts/keep/values.yaml
+++ b/charts/keep/values.yaml
@@ -192,16 +192,24 @@ backend:
   tolerations: []
   affinity: {}
   healthCheck:
-    enabled: false
+    enabled: true
     probes:
       readinessProbe:
-        tcpSocket:
+        httpGet:
+          path: /healthcheck
           port: 8080
-        initialDelaySeconds: 30
-        periodSeconds: 10
+        initialDelaySeconds: 10
+        periodSeconds: 5
+        failureThreshold: 3
+        successThreshold: 1
       livenessProbe:
-        tcpSocket:
+        httpGet:
+          path: /healthcheck
           port: 8080
+        initialDelaySeconds: 60
+        periodSeconds: 10
+        failureThreshold: 5
+        successThreshold: 1
   extraVolumeMounts: []
   extraVolumes: []
   # override the default command


### PR DESCRIPTION
## 📑 Description
Hi!

When I tried to enable default healthchecks for backend I faced with the following issue: looks like default healthchecks is not working (perhaps inappropriate timeouts, but maybe not)

My backend was broken and pod have CrashLoopBackOff status (because liveness probe was failed)

describe pod:
```
Containers:
  keep:
    Container ID:   containerd://91193f197203cd3bdd83efaa1eaaeabaea2a17fcf8b5a1114f68dd677eaa2539
    Image:          us-central1-docker.pkg.dev/keephq/keep/keep-api:0.40.13
    Image ID:       us-central1-docker.pkg.dev/keephq/keep/keep-api@sha256:df9eb73766ced4cac1dbe010450a5cf31e4e31b1b841ba4fa5b6066c7ee0af93
    Port:           8080/TCP
    Host Port:      0/TCP
    State:          Waiting
      Reason:       CrashLoopBackOff
    Last State:     Terminated
      Reason:       Error
      Exit Code:    137
      Started:      Thu, 03 Apr 2025 13:12:11 +0300
      Finished:     Thu, 03 Apr 2025 13:13:04 +0300
    Ready:          False
    Restart Count:  7
```

k8s events:
```
Events:
  Type     Reason     Age                    From               Message
  ----     ------     ----                   ----               -------
  Normal   Scheduled  14m                    default-scheduler  Successfully assigned keephq/keep-backend-cc6f99b4d-6sffl to gke-test-system-regular-2-644d-a9516dcd-lftt
  Normal   Pulled     13m                    kubelet            Successfully pulled image "us-central1-docker.pkg.dev/keephq/keep/keep-api:0.40.13" in 774ms (774ms including waiting). Image size: 324975057 bytes.
  Normal   Pulled     12m                    kubelet            Successfully pulled image "us-central1-docker.pkg.dev/keephq/keep/keep-api:0.40.13" in 879ms (879ms including waiting). Image size: 324975057 bytes.
  Normal   Pulling    12m (x3 over 14m)      kubelet            Pulling image "us-central1-docker.pkg.dev/keephq/keep/keep-api:0.40.13"
  Normal   Created    11m (x3 over 13m)      kubelet            Created container keep
  Normal   Started    11m (x3 over 13m)      kubelet            Started container keep
  Normal   Pulled     11m                    kubelet            Successfully pulled image "us-central1-docker.pkg.dev/keephq/keep/keep-api:0.40.13" in 773ms (773ms including waiting). Image size: 324975057 bytes.
  Warning  Unhealthy  11m                    kubelet            Readiness probe failed: dial tcp 172.22.177.108:8080: connect: connection refused
  Warning  Unhealthy  11m (x9 over 13m)      kubelet            Liveness probe failed: dial tcp 172.22.177.108:8080: connect: connection refused
  Normal   Killing    11m (x3 over 13m)      kubelet            Container keep failed liveness probe, will be restarted
  Normal   Pulled     8m59s (x2 over 9m59s)  kubelet            Successfully pulled image "us-central1-docker.pkg.dev/keephq/keep/keep-api:0.40.13" in 805ms (805ms including waiting). Image size: 324975057 bytes.
  Warning  BackOff    3m58s (x20 over 8m)    kubelet            Back-off restarting failed container keep in pod keep-backend-cc6f99b4d-6sffl_keephq(95bc16ab-e167-4763-9100-cf95a8a74203)
```

According to the [documentation](https://docs.keephq.dev/deployment/monitoring#healthchecks) keep backend have a `healthcheck` method. We can use this correct and k8s-native method for healthchecks instead of simple tcpSocket check.

Also according to the kubernetes bets practices healthchecks must be enabled.

I make following changes for backend healthchecks in this PR:
1) Enabling healthchecks by default (this will prevent you from running a non-working configuration, now its possible)
2) Change check from tcpSocket to httpGet
3) Change checks parameters (initialDelaySeconds, periodSeconds, failureThreshold, successThreshold) - readiness check will faster (app launch faster) and liveness probes will slowly (don't kill pod at startup process)

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed

