### PR TITLE
refactor: move openAiApi preset form .Values.backend to .Values making it commot for frontend and backend deployments

### DIFF
--- a/charts/keep/Chart.yaml
+++ b/charts/keep/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: keep
-version: 0.1.84
+version: 0.1.85
 description: Keep Helm Chart
 type: application
 icon: https://platform.keephq.dev/_next/image?url=%2Fkeep.png&w=48&q=75

--- a/charts/keep/README.md
+++ b/charts/keep/README.md
@@ -83,8 +83,6 @@ Keep Helm Chart
 | backend.image.repository | string | `"us-central1-docker.pkg.dev/keephq/keep/keep-api"` |  |
 | backend.imagePullSecrets | list | `[]` |  |
 | backend.nodeSelector | object | `{}` |  |
-| backend.openAiApi.enabled | bool | `false` |  |
-| backend.openAiApi.openAiApiKey | string | `""` |  |
 | backend.podAnnotations."prometheus.io/path" | string | `"/metrics/processing"` |  |
 | backend.podAnnotations."prometheus.io/port" | string | `"8080"` |  |
 | backend.podAnnotations."prometheus.io/scrape" | string | `"true"` |  |
@@ -233,6 +231,8 @@ Keep Helm Chart
 | isGKE | bool | `false` |  |
 | nameOverride | string | `""` |  |
 | namespace | string | `"keep"` |  |
+| openAiApi.enabled | bool | `false` |  |
+| openAiApi.openAiApiKey | string | `""` |  |
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `true` |  |
 | serviceAccount.name | string | `""` |  |

--- a/charts/keep/templates/backend.yaml
+++ b/charts/keep/templates/backend.yaml
@@ -85,9 +85,9 @@ spec:
               value: {{ tpl (.value | toString) $ | quote }}
               {{- end }}
             {{- end }}
-            {{- if .Values.backend.openAiApi.enabled }}
+            {{- if .Values.openAiApi.enabled }}
             - name: OPENAI_API_KEY
-              value: {{ .Values.backend.openAiApi.openAiApiKey | default "" | quote }}
+              value: {{ .Values.openAiApi.openAiApiKey | default "" | quote }}
             {{- end }}
             - name: K8S_NAMESPACE
               valueFrom:

--- a/charts/keep/templates/frontend.yaml
+++ b/charts/keep/templates/frontend.yaml
@@ -44,6 +44,10 @@ spec:
               containerPort: {{ .Values.frontend.service.port }}
               protocol: TCP
           env:
+            {{- if .Values.openAiApi.enabled }}
+            - name: OPENAI_API_KEY
+              value: {{ .Values.openAiApi.openAiApiKey | default "" | quote }}
+            {{- end }}
             - name: PUSHER_HOST
               value: {{ include "keep.pusherHost" . | quote }}
             - name: API_URL_CLIENT

--- a/charts/keep/values.yaml
+++ b/charts/keep/values.yaml
@@ -6,6 +6,9 @@ serviceAccount:
 nameOverride: ""
 fullnameOverride: ""
 isGKE: false
+openAiApi:
+  enabled: false
+  openAiApiKey: ""
 
 global:
   # this section controls the ingress resource at nginx-ingress.yaml
@@ -140,9 +143,6 @@ backend:
   # - name: keep-env-configmap-name
   #   prefix: prefix
   #   optional: true
-  openAiApi:
-    enabled: false
-    openAiApiKey: ""
   replicaCount: 1
   image:
     repository: us-central1-docker.pkg.dev/keephq/keep/keep-api


### PR DESCRIPTION
## 📑 Description
- [x] makes openAiApi section common for both frontend and backend
- [x] updated doc accordingly

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ℹ Additional Information
Probably version 0.2.0 as there are important changes without backwards compatibility
