### PR TITLE
chore: bump version to 0.43.12 and allow setting custom KEEP_API_URL

### DIFF
--- a/charts/keep/Chart.yaml
+++ b/charts/keep/Chart.yaml
@@ -4,7 +4,7 @@ version: 0.1.88
 description: Keep Helm Chart
 type: application
 icon: https://platform.keephq.dev/_next/image?url=%2Fkeep.png&w=48&q=75
-appVersion: 0.43.4
+appVersion: 0.43.12
 deprecated: false
 annotations:
   app: keep

--- a/charts/keep/Chart.yaml
+++ b/charts/keep/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: keep
-version: 0.1.88
+version: 0.1.89
 description: Keep Helm Chart
 type: application
 icon: https://platform.keephq.dev/_next/image?url=%2Fkeep.png&w=48&q=75

--- a/charts/keep/README.md
+++ b/charts/keep/README.md
@@ -1,6 +1,6 @@
 # keep
 
-![Version: 0.1.88](https://img.shields.io/badge/Version-0.1.88-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.43.12](https://img.shields.io/badge/AppVersion-0.43.12-informational?style=flat-square)
+![Version: 0.1.89](https://img.shields.io/badge/Version-0.1.89-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.43.12](https://img.shields.io/badge/AppVersion-0.43.12-informational?style=flat-square)
 
 Keep Helm Chart
 

--- a/charts/keep/README.md
+++ b/charts/keep/README.md
@@ -1,6 +1,6 @@
 # keep
 
-![Version: 0.1.86](https://img.shields.io/badge/Version-0.1.86-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.43.0](https://img.shields.io/badge/AppVersion-0.42.5-informational?style=flat-square)
+![Version: 0.1.88](https://img.shields.io/badge/Version-0.1.88-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.43.12](https://img.shields.io/badge/AppVersion-0.43.12-informational?style=flat-square)
 
 Keep Helm Chart
 

--- a/charts/keep/templates/backend.yaml
+++ b/charts/keep/templates/backend.yaml
@@ -59,10 +59,18 @@ spec:
               containerPort: {{ .Values.backend.service.port }}
               protocol: TCP
           env:
+            {{- $keepApiUrlExists := false -}}
+            {{- range .Values.backend.env -}}
+              {{- if eq .name "KEEP_API_URL" -}}
+                {{- $keepApiUrlExists = true -}}
+              {{- end -}}
+            {{- end -}}
+            {{- if not $keepApiUrlExists }}
             - name: KEEP_API_URL
               value: {{ include "keep.keepApiUrl" . | quote }}
+            {{- end }}
             {{- if .Values.backend.provision.workflows }}
-            - name: KEEP_WORKFLOWS_DIRECTORY  
+            - name: KEEP_WORKFLOWS_DIRECTORY
               value: /workflows
             {{- end }}
             {{- range .Values.backend.env }}


### PR DESCRIPTION
## 📑 Description
- Upgrade to 0.43.12
- Allow setting custom `KEEP_API_URL` from `.Values.backend.env`. Currently you would have a duplicate of `KEEP_API_URL` if you try to set it  via the `.Values.backend.env`
