### PR TITLE
fix: Adding missing OpenAI environment variables.

### DIFF
--- a/charts/keep/templates/backend.yaml
+++ b/charts/keep/templates/backend.yaml
@@ -96,6 +96,12 @@ spec:
             {{- if .Values.openAiApi.enabled }}
             - name: OPENAI_API_KEY
               value: {{ .Values.openAiApi.openAiApiKey | default "" | quote }}
+            - name: OPENAI_MODEL_NAME
+              value: {{ .Values.openAiApi.openAiModelName | default "" | quote }}
+            - name: OPEN_AI_ORGANIZATION_ID
+              value: {{ .Values.openAiApi.openAiOrganizationId | default "" | quote }}
+            - name: OPENAI_BASE_URL
+              value: {{ .Values.openAiApi.openAiBaseUrl | default "" | quote }}
             {{- end }}
             - name: K8S_NAMESPACE
               valueFrom:

--- a/charts/keep/templates/frontend.yaml
+++ b/charts/keep/templates/frontend.yaml
@@ -47,6 +47,12 @@ spec:
             {{- if .Values.openAiApi.enabled }}
             - name: OPENAI_API_KEY
               value: {{ .Values.openAiApi.openAiApiKey | default "" | quote }}
+            - name: OPENAI_MODEL_NAME
+              value: {{ .Values.openAiApi.openAiModelName | default "" | quote }}
+            - name: OPEN_AI_ORGANIZATION_ID
+              value: {{ .Values.openAiApi.openAiOrganizationId | default "" | quote }}
+            - name: OPENAI_BASE_URL
+              value: {{ .Values.openAiApi.openAiBaseUrl | default "" | quote }}
             {{- end }}
             - name: PUSHER_HOST
               value: {{ include "keep.pusherHost" . | quote }}

--- a/charts/keep/values.yaml
+++ b/charts/keep/values.yaml
@@ -9,6 +9,9 @@ isGKE: false
 openAiApi:
   enabled: false
   openAiApiKey: ""
+  openAiModelName: ""
+  openAiOrganizationId: ""
+  openAiBaseUrl: ""
 
 global:
   # this section controls the ingress resource at nginx-ingress.yaml


### PR DESCRIPTION
Adding the following missing environment variables for both frontend and backend deployments, configurable via values.yaml under the openAiApi section:

- OPENAI_MODEL_NAME
- OPEN_AI_ORGANIZATION_ID
- OPENAI_BASE_URL

These variables will allow you to customize your OpenAI integration

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
