### PR TITLE
fix: removes duplicated definition of nginx ingress class on ingress-nginx.yaml

### DIFF
--- a/charts/keep/Chart.yaml
+++ b/charts/keep/Chart.yaml
@@ -1,10 +1,10 @@
 apiVersion: v2
 name: keep
-version: 0.1.92
+version: 0.1.93
 description: Keep Helm Chart
 type: application
 icon: https://platform.keephq.dev/_next/image?url=%2Fkeep.png&w=48&q=75
-appVersion: 0.45.4
+appVersion: 0.45.5
 deprecated: false
 annotations:
   app: keep

--- a/charts/keep/templates/ingress-nginx.yaml
+++ b/charts/keep/templates/ingress-nginx.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/component: networking
   annotations:
     {{- if or (eq .Values.global.ingress.className "nginx") (eq .Values.global.ingress.classType "nginx") }}
-    kubernetes.io/ingress.class: {{ .Values.global.ingress.className }}
     nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
     nginx.ingress.kubernetes.io/proxy-connect-timeout: "3600"


### PR DESCRIPTION
Closes #173

## 📑 Description
<!-- Add a brief description of the pr -->
This PR erases an annotation in the ingress-nginx.yaml template which results on a Helm error at deployment time.

This fix has been tested locally with success.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
