### PR TITLE
fix: actually implement rendered config map and secrets

### DIFF
--- a/charts/keep/templates/backend-configs.yaml
+++ b/charts/keep/templates/backend-configs.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.backend.envRenderSecret }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "keep.fullname" . }}-backend-env-secret
+  labels:
+    {{- include "keep.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+type: Opaque
+stringData:
+  {{- range $key, $value := .Values.backend.envRenderSecret }}
+  {{ $key }}: {{ (tpl $value .) | quote }}
+  {{- end }}
+{{- end }}
+
+{{- if .Values.backend.envRender }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "keep.fullname" . }}-backend-env
+  labels:
+    {{- include "keep.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+data:
+  {{- range $key, $value := .Values.backend.envRender }}
+  {{ $key }}: {{ (tpl $value .) | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/keep/templates/backend.yaml
+++ b/charts/keep/templates/backend.yaml
@@ -22,6 +22,12 @@ spec:
         # Force reload on provision changes
         checksum/provision-providers: {{ .Values.backend.provision.providers | toYaml | sha256sum }}
         checksum/provision-workflows: {{ .Values.backend.provision.workflows | toYaml | sha256sum }}
+        {{- if .Values.backend.envRender }}
+        checksum/backend-env: {{ .Values.backend.envRender | toYaml | sha256sum }}
+        {{- end }}
+        {{- if .Values.backend.envRenderSecret }}
+        checksum/backend-env-secret: {{ .Values.backend.envRenderSecret | toYaml | sha256sum }}
+        {{- end }}
         {{- range $key, $value := .Values.backend.podAnnotations }}
         {{- if kindIs "string" $value }}
         {{ $key }}: {{ tpl $value $ | quote }}
@@ -108,7 +114,7 @@ spec:
                   name: {{ .Values.backend.databaseConnectionStringFromSecret.secretName }}
                   key: {{ .Values.backend.databaseConnectionStringFromSecret.secretKey }}
             {{- end }}
-          {{- if or .Values.backend.provision.providers .Values.backend.envFromSecret (or .Values.backend.envRenderSecret .Values.backend.envFromSecrets) .Values.backend.envFromConfigMaps }}
+          {{- if or .Values.backend.provision.providers .Values.backend.envFromSecret (or .Values.backend.envRenderSecret .Values.backend.envFromSecrets) .Values.backend.envFromConfigMaps .Values.backend.envRender }}
           envFrom:
             {{- if .Values.backend.provision.providers }}
             - secretRef:
@@ -120,6 +126,10 @@ spec:
             {{- end }}
             {{- if .Values.backend.envRenderSecret }}
             - secretRef:
+                name: {{ include "keep.fullname" . }}-backend-env-secret
+            {{- end }}
+            {{- if .Values.backend.envRender }}
+            - configMapRef:
                 name: {{ include "keep.fullname" . }}-backend-env
             {{- end }}
             {{- range .Values.backend.envFromSecrets }}

--- a/charts/keep/templates/frontend-configs.yaml
+++ b/charts/keep/templates/frontend-configs.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.frontend.envRenderSecret }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "keep.fullname" . }}-frontend-env-secret
+  labels:
+    {{- include "keep.labels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+type: Opaque
+stringData:
+  {{- range $key, $value := .Values.frontend.envRenderSecret }}
+  {{ $key }}: {{ (tpl $value .) | quote }}
+  {{- end }}
+{{- end }}
+
+{{- if .Values.frontend.envRender }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "keep.fullname" . }}-frontend-env
+  labels:
+    {{- include "keep.labels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+data:
+  {{- range $key, $value := .Values.frontend.envRender }}
+  {{ $key }}: {{ (tpl $value .) | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/keep/templates/frontend.yaml
+++ b/charts/keep/templates/frontend.yaml
@@ -17,9 +17,17 @@ spec:
       keep-component: frontend
   template:
     metadata:
-      {{- with .Values.frontend.podAnnotations }}
+      {{- if or .Values.frontend.podAnnotations .Values.frontend.envRender .Values.frontend.envRenderSecret }}
       annotations:
+        {{- if .Values.frontend.envRender }}
+        checksum/frontend-env: {{ .Values.frontend.envRender | toYaml | sha256sum }}
+        {{- end }}
+        {{- if .Values.frontend.envRenderSecret }}
+        checksum/frontend-env-secret: {{ .Values.frontend.envRenderSecret | toYaml | sha256sum }}
+        {{- end }}
+        {{- with .Values.frontend.podAnnotations }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
       labels:
         {{- include "keep.labels" . | nindent 8 }}
@@ -66,7 +74,7 @@ spec:
               value: {{ .value | quote }}
             {{- end }}
             {{- end }}
-          {{- if or .Values.frontend.envFromSecret (or .Values.frontend.envRenderSecret .Values.frontend.envFromSecrets) .Values.frontend.envFromConfigMaps }}
+          {{- if or .Values.frontend.envFromSecret (or .Values.frontend.envRenderSecret .Values.frontend.envFromSecrets) .Values.frontend.envFromConfigMaps .Values.frontend.envRender }}
           envFrom:
             {{- if .Values.frontend.envFromSecret }}
             - secretRef:
@@ -74,6 +82,10 @@ spec:
             {{- end }}
             {{- if .Values.frontend.envRenderSecret }}
             - secretRef:
+                name: {{ include "keep.fullname" . }}-frontend-env-secret
+            {{- end }}
+            {{- if .Values.frontend.envRender }}
+            - configMapRef:
                 name: {{ include "keep.fullname" . }}-frontend-env
             {{- end }}
             {{- range .Values.frontend.envFromSecrets }}

--- a/charts/keep/templates/frontend.yaml
+++ b/charts/keep/templates/frontend.yaml
@@ -124,7 +124,7 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.backend.topologySpreadConstraints }}
+      {{- with .Values.frontend.topologySpreadConstraints }}
       topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/keep/values.yaml
+++ b/charts/keep/values.yaml
@@ -131,6 +131,9 @@ backend:
   # -- Sensible environment variables will be rendered as a new secret object; escape {{ in secret values to avoid Helm interpretation.
   envRenderSecret: {}
 
+  # -- Sensible environment variables will be rendered as a new configmap object; escape {{ in secret values to avoid Helm interpretation.
+  envRender: {}
+
   # -- List of secrets to include. Must include name and can be marked as optional.
   envFromSecrets: []
   # - name: keep-secret-name
@@ -259,7 +262,8 @@ frontend:
       value: "true"
   # -- Name of the secret to include
   envFromSecret: ""
-
+  # -- Sensible environment variables will be rendered as a new configmap object; escape {{ in secret values to avoid Helm interpretation.
+  envRender: {}
   # -- Sensible environment variables will be rendered as a new secret object; escape {{ in secret values to avoid Helm interpretation.
   envRenderSecret: {}
 


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # N/A

## 📑 Description
This implements and extends the envRender environment variables for both the frontend and backend to provision corresponding configmaps and secrets

ION:
- fixed a mismatched reference to the topology spread in the frontend

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
