### PR TITLE
feat: allow setting the restartPolicy for an initContainer

### DIFF
--- a/charts/keep/templates/backend.yaml
+++ b/charts/keep/templates/backend.yaml
@@ -181,6 +181,9 @@ spec:
           {{- with .volumeMounts }}
           volumeMounts: {{ toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .restartPolicy }}
+          restartPolicy: {{ toYaml . | nindent 12 }}
+          {{- end }}
         {{- end }}
 
       {{- with .Values.backend.nodeSelector }}

--- a/charts/keep/templates/backend.yaml
+++ b/charts/keep/templates/backend.yaml
@@ -182,7 +182,7 @@ spec:
           volumeMounts: {{ toYaml . | nindent 12 }}
           {{- end }}
           {{- with .restartPolicy }}
-          restartPolicy: {{ toYaml . | nindent 12 }}
+          restartPolicy: {{ tpl (toYaml .) $ | nindent 12 }}
           {{- end }}
         {{- end }}
 

--- a/charts/keep/templates/backend.yaml
+++ b/charts/keep/templates/backend.yaml
@@ -182,7 +182,7 @@ spec:
           volumeMounts: {{ toYaml . | nindent 12 }}
           {{- end }}
           {{- with .restartPolicy }}
-          restartPolicy: {{ tpl (toYaml .) $ | nindent 12 }}
+          restartPolicy: {{ . }}
           {{- end }}
         {{- end }}
 


### PR DESCRIPTION
Closes # #179

## 📑 Description
Adds templating of `restartPolicy` to the Helm chart, allowing the user to run Kubernetes native sidecars as `initContainers`.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed
