### PR TITLE
fix(helm): add explicit namespace to all resource templates

### DIFF
--- a/charts/keep/templates/backend-hpa.yaml
+++ b/charts/keep/templates/backend-hpa.yaml
@@ -3,6 +3,7 @@ apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "keep.fullname" . }}-backend
+  namespace: {{ include "keep.namespace" . }}
   labels:
     {{- include "keep.labels" . | nindent 4 }}
     app.kubernetes.io/component: backend

--- a/charts/keep/templates/backend-provision.yaml
+++ b/charts/keep/templates/backend-provision.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "keep.fullname" . }}-providers
+  namespace: {{ include "keep.namespace" . }}
   labels:
     {{- include "keep.labels" . | nindent 4 }}
     app.kubernetes.io/component: backend
@@ -19,6 +20,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "keep.fullname" . }}-workflows
+  namespace: {{ include "keep.namespace" . }}
   labels:
     {{- include "keep.labels" . | nindent 4 }}
     app.kubernetes.io/component: backend

--- a/charts/keep/templates/backend-route.yaml
+++ b/charts/keep/templates/backend-route.yaml
@@ -4,6 +4,7 @@ apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   name: {{ $fullName }}
+  namespace: {{ include "keep.namespace" . }}
   labels:
     {{- include "keep.labels" . | nindent 4 }}
     app.kubernetes.io/component: backend

--- a/charts/keep/templates/backend-service.yaml
+++ b/charts/keep/templates/backend-service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "keep.fullname" . }}-backend
+  namespace: {{ include "keep.namespace" . }}
   labels:
     {{- include "keep.labels" . | nindent 4 }}
     app.kubernetes.io/component: backend

--- a/charts/keep/templates/backend.yaml
+++ b/charts/keep/templates/backend.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "keep.fullname" . }}-backend
+  namespace: {{ include "keep.namespace" . }}
   labels:
     {{- include "keep.labels" . | nindent 4 }}
     app.kubernetes.io/component: backend

--- a/charts/keep/templates/db-cleanup-cronjob.yaml
+++ b/charts/keep/templates/db-cleanup-cronjob.yaml
@@ -3,6 +3,7 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ include "keep.fullname" . }}-db-cleanup
+  namespace: {{ include "keep.namespace" . }}
   labels:
     {{- include "keep.labels" . | nindent 4 }}
     app.kubernetes.io/component: database

--- a/charts/keep/templates/db-configmap.yaml
+++ b/charts/keep/templates/db-configmap.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "keep.fullname" . }}-mysql-config
+  namespace: {{ include "keep.namespace" . }}
   labels:
     {{- include "keep.labels" . | nindent 4 }}
     app.kubernetes.io/component: database

--- a/charts/keep/templates/db-pvc.yaml
+++ b/charts/keep/templates/db-pvc.yaml
@@ -6,6 +6,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ $pvcName }}
+  namespace: {{ include "keep.namespace" . }}
   annotations:
     {{- if .Values.database.pvc.retain }}
     helm.sh/resource-policy: keep

--- a/charts/keep/templates/db-service.yaml
+++ b/charts/keep/templates/db-service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "keep.name" . }}-database
+  namespace: {{ include "keep.namespace" . }}
   labels:
     {{- include "keep.labels" . | nindent 4 }}
     app.kubernetes.io/component: database

--- a/charts/keep/templates/db.yaml
+++ b/charts/keep/templates/db.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "keep.fullname" . }}-database
+  namespace: {{ include "keep.namespace" . }}
   labels:
     {{- include "keep.labels" . | nindent 4 }}
     app.kubernetes.io/component: database

--- a/charts/keep/templates/delete-secret-job.yaml
+++ b/charts/keep/templates/delete-secret-job.yaml
@@ -2,6 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: delete-keep-secrets
+  namespace: {{ include "keep.namespace" . }}
   annotations:
     "helm.sh/hook": pre-delete
     "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"

--- a/charts/keep/templates/frontend-hpa.yaml
+++ b/charts/keep/templates/frontend-hpa.yaml
@@ -3,6 +3,7 @@ apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "keep.fullname" . }}-frontend
+  namespace: {{ include "keep.namespace" . }}
   labels:
     {{- include "keep.labels" . | nindent 4 }}
     app.kubernetes.io/component: frontend

--- a/charts/keep/templates/frontend-route.yaml
+++ b/charts/keep/templates/frontend-route.yaml
@@ -4,6 +4,7 @@ apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   name: {{ $fullName }}
+  namespace: {{ include "keep.namespace" . }}
   labels:
     {{- include "keep.labels" . | nindent 4 }}
     app.kubernetes.io/component: frontend

--- a/charts/keep/templates/frontend-service.yaml
+++ b/charts/keep/templates/frontend-service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "keep.fullname" . }}-frontend
+  namespace: {{ include "keep.namespace" . }}
   labels:
     {{- include "keep.labels" . | nindent 4 }}
     app.kubernetes.io/component: frontend

--- a/charts/keep/templates/frontend.yaml
+++ b/charts/keep/templates/frontend.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "keep.fullname" . }}-frontend
+  namespace: {{ include "keep.namespace" . }}
   labels:
     {{- include "keep.labels" . | nindent 4 }}
     app.kubernetes.io/component: frontend

--- a/charts/keep/templates/gke/backend-gke-healthcheck-config.yaml
+++ b/charts/keep/templates/gke/backend-gke-healthcheck-config.yaml
@@ -3,7 +3,7 @@ apiVersion: cloud.google.com/v1
 kind: BackendConfig
 metadata:
   name: {{ include "keep.fullname" . }}-backend-backendconfig
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "keep.namespace" . }}
 spec:
   healthCheck:
     checkIntervalSec: {{ .Values.frontend.backendConfig.healthCheck.checkIntervalSec }}

--- a/charts/keep/templates/gke/frontend-gke-healthcheck-config.yaml
+++ b/charts/keep/templates/gke/frontend-gke-healthcheck-config.yaml
@@ -3,7 +3,7 @@ apiVersion: cloud.google.com/v1
 kind: BackendConfig
 metadata:
   name: {{ include "keep.fullname" . }}-frontend-backendconfig
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "keep.namespace" . }}
 spec:
   healthCheck:
     checkIntervalSec: {{ .Values.frontend.backendConfig.healthCheck.checkIntervalSec }}

--- a/charts/keep/templates/ingress-haproxy.yaml
+++ b/charts/keep/templates/ingress-haproxy.yaml
@@ -4,6 +4,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}-ingress
+  namespace: {{ include "keep.namespace" . }}
   labels:
     {{- include "keep.labels" . | nindent 4 }}
     app.kubernetes.io/component: networking

--- a/charts/keep/templates/ingress-nginx.yaml
+++ b/charts/keep/templates/ingress-nginx.yaml
@@ -4,6 +4,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}-ingress
+  namespace: {{ include "keep.namespace" . }}
   labels:
     {{- include "keep.labels" . | nindent 4 }}
     app.kubernetes.io/component: networking

--- a/charts/keep/templates/ingress-traefik-middleware.yaml
+++ b/charts/keep/templates/ingress-traefik-middleware.yaml
@@ -3,7 +3,7 @@ apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   name: strip-prefix
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "keep.namespace" . }}
   labels:
     {{- include "keep.labels" . | nindent 4 }}
     app.kubernetes.io/component: networking

--- a/charts/keep/templates/ingress-traefik.yaml
+++ b/charts/keep/templates/ingress-traefik.yaml
@@ -4,6 +4,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}-ingress
+  namespace: {{ include "keep.namespace" . }}
   labels:
     {{- include "keep.labels" . | nindent 4 }}
     app.kubernetes.io/component: networking

--- a/charts/keep/templates/serviceaccount.yaml
+++ b/charts/keep/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "keep.serviceAccountName" . }}
+  namespace: {{ include "keep.namespace" . }}
   labels:
     {{- include "keep.labels" . | nindent 4 }}
     app.kubernetes.io/component: rbac

--- a/charts/keep/templates/websocket-hpa.yaml
+++ b/charts/keep/templates/websocket-hpa.yaml
@@ -3,6 +3,7 @@ apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "keep.fullname" . }}-websocket
+  namespace: {{ include "keep.namespace" . }}
   labels:
     {{- include "keep.labels" . | nindent 4 }}
     app.kubernetes.io/component: websocket

--- a/charts/keep/templates/websocket-route.yaml
+++ b/charts/keep/templates/websocket-route.yaml
@@ -4,6 +4,7 @@ apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   name: {{ $fullName }}-websocket
+  namespace: {{ include "keep.namespace" . }}
   labels:
     {{- include "keep.labels" . | nindent 4 }}
     app.kubernetes.io/component: websocket

--- a/charts/keep/templates/websocket-server-service.yaml
+++ b/charts/keep/templates/websocket-server-service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "keep.fullname" . }}-websocket
+  namespace: {{ include "keep.namespace" . }}
   labels:
     {{- include "keep.labels" . | nindent 4 }}
     app.kubernetes.io/component: websocket

--- a/charts/keep/templates/websocket-server.yaml
+++ b/charts/keep/templates/websocket-server.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "keep.fullname" . }}-websocket
+  namespace: {{ include "keep.namespace" . }}
   labels:
     {{- include "keep.labels" . | nindent 4 }}
     app.kubernetes.io/component: websocket


### PR DESCRIPTION
## 📑 Description

Add `namespace: {{ include "keep.namespace" . }}` to all Kubernetes resource templates that were missing it. This ensures proper namespace handling when deploying via tools like kustomize that rely on namespace being explicitly set in resource metadata.

Resources updated:
- ServiceAccount
- Deployments (backend, frontend, websocket, database)
- Services (backend, frontend, websocket, database)
- HorizontalPodAutoscalers
- Secrets and ConfigMaps
- PersistentVolumeClaim
- CronJob (db-cleanup)
- Job (delete-secret)
- Ingresses (nginx, haproxy, traefik)
- Routes (OpenShift)

Also updated GKE BackendConfig and Traefik Middleware templates to use the `keep.namespace` helper instead of `.Release.Namespace` for consistency.

Note: PersistentVolume (db-pv.yaml) is intentionally excluded as it is a cluster-scoped resource that does not have a namespace.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [x] All the tests have passed

