### PR TITLE
feat(keep): add opt-in Gateway API HTTPRoute support

### DIFF
--- a/charts/keep/Chart.yaml
+++ b/charts/keep/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: keep
-version: 0.1.96
+version: 0.1.97
 description: Keep Helm Chart
 type: application
 icon: https://platform.keephq.dev/_next/image?url=%2Fkeep.png&w=48&q=75

--- a/charts/keep/README.md
+++ b/charts/keep/README.md
@@ -219,6 +219,10 @@ Keep Helm Chart
 | frontend.tolerations | list | `[]` |  |
 | frontend.topologySpreadConstraints | list | `[]` |  |
 | fullnameOverride | string | `""` |  |
+| global.httpRoute.annotations | object | `{}` |  |
+| global.httpRoute.enabled | bool | `false` |  |
+| global.httpRoute.hostnames | list | `[]` |  |
+| global.httpRoute.parentRefs | list | `[]` |  |
 | global.ingress.annotations | object | `{}` |  |
 | global.ingress.backendPrefix | string | `"/v2"` |  |
 | global.ingress.className | string | `"nginx"` |  |

--- a/charts/keep/templates/httproute.yaml
+++ b/charts/keep/templates/httproute.yaml
@@ -1,0 +1,65 @@
+{{- if .Values.global.httpRoute.enabled }}
+{{- $fullName := include "keep.fullname" . }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}-httproute
+  labels:
+    {{- include "keep.labels" . | nindent 4 }}
+    app.kubernetes.io/component: networking
+  {{- with .Values.global.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.global.httpRoute.parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.global.httpRoute.hostnames }}
+  hostnames:
+    {{- range . }}
+    - {{ . | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- if .Values.websocket.enabled }}
+    # WebSocket prefix strips to "/" before forwarding, mirroring the nginx rewrite.
+    - matches:
+        - path:
+            type: PathPrefix
+            value: {{ .Values.global.ingress.websocketPrefix | quote }}
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: /
+      backendRefs:
+        - name: {{ $fullName }}-websocket
+          port: {{ .Values.websocket.service.port }}
+    {{- end }}
+    {{- if .Values.backend.enabled }}
+    - matches:
+        - path:
+            type: PathPrefix
+            value: {{ .Values.global.ingress.backendPrefix | quote }}
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: /
+      backendRefs:
+        - name: {{ $fullName }}-backend
+          port: {{ .Values.backend.service.port }}
+    {{- end }}
+    # Frontend catch-all; longer prefixes above win by Gateway API path-specificity precedence.
+    - matches:
+        - path:
+            type: PathPrefix
+            value: {{ .Values.global.ingress.frontendPrefix | quote }}
+      backendRefs:
+        - name: {{ $fullName }}-frontend
+          port: {{ .Values.frontend.service.port }}
+{{- end }}

--- a/charts/keep/values.yaml
+++ b/charts/keep/values.yaml
@@ -42,6 +42,27 @@ global:
     #       - keep.example.com
     #    secretName: keep-tls
 
+  # this section controls the Gateway API HTTPRoute at httproute.yaml
+  # opt-in alternative to the nginx Ingress above for clusters using the
+  # Kubernetes Gateway API (e.g. Envoy Gateway, Istio, Cilium)
+  httpRoute:
+    enabled: false
+    # references to the Gateway(s) this route should attach to
+    parentRefs: []
+    # parentRefs:
+    #   - name: my-gateway
+    #     namespace: gateway-system
+    #     sectionName: https
+    # hostnames the route matches (leave empty to inherit the Gateway's)
+    hostnames: []
+    # hostnames:
+    #   - keep.example.com
+    # extra annotations for the HTTPRoute resource
+    annotations: {}
+    # the path prefixes are reused from global.ingress above
+    # (websocketPrefix / backendPrefix / frontendPrefix) so routing stays
+    # consistent whichever mechanism is enabled
+
 # Additional labels that should be applied to all resources
 additionalLabels:
   {}


### PR DESCRIPTION
Adds an opt-in HTTPRoute template (global.httpRoute.enabled, default false)
as a Gateway API alternative to the existing nginx Ingress, for clusters
moving off ingress-nginx (Envoy Gateway / Istio / Cilium). Closes #183.

The route mirrors the nginx ingress path layout: websocket (/websocket),
backend (/v2) and frontend (/) prefixes to their services, using a
URLRewrite ReplacePrefixMatch filter to reproduce the prefix strip. The
websocket and backend rules are gated by their .enabled flags like the
ingress template. Longer prefixes win by Gateway API path-specificity
precedence, so the frontend / rule acts as the catch-all.

Validation (helm 3.18.1 + chart-testing):
- ct lint green (yamale + yamllint + helm lint), version bumped 0.1.96 -> 0.1.97
- default render: no HTTPRoute emitted, Ingress unchanged (no regression)
- enabled render: single HTTPRoute with 3 rules, correct backendRefs/ports (6001/8080/3000)
- partial render (websocket+backend disabled): only the frontend rule

related: #183
