### PR TITLE
feat(keep): add opt-in PodDisruptionBudget support

### DIFF
--- a/charts/keep/Chart.yaml
+++ b/charts/keep/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: keep
-version: 0.1.96
+version: 0.1.97
 description: Keep Helm Chart
 type: application
 icon: https://platform.keephq.dev/_next/image?url=%2Fkeep.png&w=48&q=75

--- a/charts/keep/README.md
+++ b/charts/keep/README.md
@@ -86,6 +86,8 @@ Keep Helm Chart
 | backend.podAnnotations."prometheus.io/path" | string | `"/metrics/processing"` |  |
 | backend.podAnnotations."prometheus.io/port" | string | `"8080"` |  |
 | backend.podAnnotations."prometheus.io/scrape" | string | `"true"` |  |
+| backend.podDisruptionBudget.enabled | bool | `false` |  |
+| backend.podDisruptionBudget.minAvailable | int | `1` |  |
 | backend.podSecurityContext | object | `{}` |  |
 | backend.provision.providers | object | `{}` |  |
 | backend.provision.workflows | list | `[]` |  |
@@ -202,6 +204,8 @@ Keep Helm Chart
 | frontend.imagePullSecrets | list | `[]` |  |
 | frontend.nodeSelector | object | `{}` |  |
 | frontend.podAnnotations | object | `{}` |  |
+| frontend.podDisruptionBudget.enabled | bool | `false` |  |
+| frontend.podDisruptionBudget.minAvailable | int | `1` |  |
 | frontend.podSecurityContext | object | `{}` |  |
 | frontend.replicaCount | int | `1` |  |
 | frontend.resources | object | `{}` |  |
@@ -266,6 +270,8 @@ Keep Helm Chart
 | websocket.imagePullSecrets | list | `[]` |  |
 | websocket.nodeSelector | object | `{}` |  |
 | websocket.podAnnotations | object | `{}` |  |
+| websocket.podDisruptionBudget.enabled | bool | `false` |  |
+| websocket.podDisruptionBudget.minAvailable | int | `1` |  |
 | websocket.podSecurityContext | object | `{}` |  |
 | websocket.replicaCount | int | `1` |  |
 | websocket.resources | object | `{}` |  |

--- a/charts/keep/templates/backend-pdb.yaml
+++ b/charts/keep/templates/backend-pdb.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.backend.enabled .Values.backend.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "keep.fullname" . }}-backend
+  labels:
+    {{- include "keep.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+spec:
+  {{- if .Values.backend.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.backend.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  {{- if .Values.backend.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.backend.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "keep.selectorLabels" . | nindent 6 }}
+      keep-component: backend
+{{- end }}

--- a/charts/keep/templates/frontend-pdb.yaml
+++ b/charts/keep/templates/frontend-pdb.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.frontend.enabled .Values.frontend.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "keep.fullname" . }}-frontend
+  labels:
+    {{- include "keep.labels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+spec:
+  {{- if .Values.frontend.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.frontend.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  {{- if .Values.frontend.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.frontend.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "keep.selectorLabels" . | nindent 6 }}
+      keep-component: frontend
+{{- end }}

--- a/charts/keep/templates/websocket-pdb.yaml
+++ b/charts/keep/templates/websocket-pdb.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.websocket.enabled .Values.websocket.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "keep.fullname" . }}-websocket
+  labels:
+    {{- include "keep.labels" . | nindent 4 }}
+    app.kubernetes.io/component: websocket
+spec:
+  {{- if .Values.websocket.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.websocket.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  {{- if .Values.websocket.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.websocket.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "keep.selectorLabels" . | nindent 6 }}
+      keep-component: websocket
+{{- end }}

--- a/charts/keep/values.yaml
+++ b/charts/keep/values.yaml
@@ -196,6 +196,10 @@ backend:
   topologySpreadConstraints: []
   tolerations: []
   affinity: {}
+  podDisruptionBudget:
+    enabled: false
+    minAvailable: 1
+    # maxUnavailable: ""
   healthCheck:
     enabled: true
     probes:
@@ -329,6 +333,10 @@ frontend:
   topologySpreadConstraints: []
   tolerations: []
   affinity: {}
+  podDisruptionBudget:
+    enabled: false
+    minAvailable: 1
+    # maxUnavailable: ""
   healthCheck:
     enabled: false
     probes:
@@ -383,6 +391,10 @@ websocket:
   topologySpreadConstraints: []
   tolerations: []
   affinity: {}
+  podDisruptionBudget:
+    enabled: false
+    minAvailable: 1
+    # maxUnavailable: ""
   healthCheck:
     enabled: false
     probes:


### PR DESCRIPTION
Adds an opt-in PodDisruptionBudget for the three HA components (backend, frontend, websocket), each of which already ships an HPA. Disabled by default; when enabled it defaults to `minAvailable: 1` with an optional `maxUnavailable` override.

Validation:
- `helm template`: 3 PDBs render when enabled, 0 by default, `maxUnavailable` override omits `minAvailable` correctly
- `ct lint` (yamale + yamllint + helm lint) all passed; chart version bumped 0.1.96 -> 0.1.97
- helm-docs v1.14.2 values-table rows added for the new keys

Closes #109