### PR TITLE
refactor: Ingress Nginx in favour of Kubernetes-native annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,29 +9,10 @@ Full documentation can be found at [Keep Docs](https://docs.keephq.dev/deploymen
 ## Ingress Controller (Recommended)
 The recommended way to deploy Keep is with ingress-nginx that serves as a single ingress for all services (backend, frontend, and websocket server).
 
-1. Install ingress-nginx:
 ```bash
 helm upgrade --install ingress-nginx ingress-nginx \
   --repo https://kubernetes.github.io/ingress-nginx \
   --namespace ingress-nginx --create-namespace
-```
-
-2. Enable snippet annotations:
-The ingress controller must have snippet annotations enabled. You can enable it during installation:
-```bash
-helm upgrade --install ingress-nginx ingress-nginx \
-  --repo https://kubernetes.github.io/ingress-nginx \
-  --namespace ingress-nginx --create-namespace \
-  --set controller.config.allow-snippet-annotations=true
-```
-
-To verify if snippet annotations are enabled:
-```bash
-# Check the configmap
-kubectl get configmap -n ingress-nginx ingress-nginx-controller -o yaml | grep allow-snippet-annotations
-
-# Or check the controller logs
-kubectl logs -n ingress-nginx -l app.kubernetes.io/component=controller | grep "allow-snippet-annotations"
 ```
 
 # Installation

--- a/charts/keep/templates/ingress-nginx.yaml
+++ b/charts/keep/templates/ingress-nginx.yaml
@@ -17,27 +17,7 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-http-version: "1.1"
     nginx.ingress.kubernetes.io/use-http2: "false"
     nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      if ($request_uri ~* ^({{ .Values.global.ingress.websocketPrefix }}|{{ .Values.global.ingress.backendPrefix }}|{{ .Values.global.ingress.frontendPrefix }})(/|$)(.*)) {
-        rewrite ^({{ .Values.global.ingress.websocketPrefix }}|{{ .Values.global.ingress.backendPrefix }}|{{ .Values.global.ingress.frontendPrefix }})(/|$)(.*) /$3 break;
-      }
-    nginx.ingress.kubernetes.io/server-snippet: |
-      {{- if $.Values.websocket.enabled }}
-      location ^~ {{ .Values.global.ingress.websocketPrefix }} {
-        rewrite ^{{ .Values.global.ingress.websocketPrefix }}(/|$)(.*) /$2 break;
-        proxy_pass http://{{ $fullName }}-websocket.{{ .Release.Namespace }}.svc.cluster.local:{{ $.Values.websocket.service.port }};
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header X-Forwarded-Host $http_host;
-        proxy_cache_bypass $http_upgrade;
-      }
-      {{- end }}
-    nginx.ingress.kubernetes.io/rewrite-target: /$1
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
     nginx.ingress.kubernetes.io/use-regex: "true"
     {{- end }}
     {{- with .Values.global.ingress.annotations }}
@@ -79,7 +59,7 @@ spec:
               port:
                 number: {{ $.Values.backend.service.port }}
         {{- end }}
-        - path: {{ $.Values.global.ingress.frontendPrefix }}(.*)
+        - path: {{ $.Values.global.ingress.frontendPrefix }}()(.*)
           pathType: ImplementationSpecific
           backend:
             service:
@@ -108,7 +88,7 @@ spec:
               port:
                 number: {{ $.Values.backend.service.port }}
         {{- end }}
-        - path: {{ $.Values.global.ingress.frontendPrefix }}(.*)
+        - path: {{ $.Values.global.ingress.frontendPrefix }}()(.*)
           pathType: ImplementationSpecific
           backend:
             service:


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #201 <!-- Issue # here -->

## 📑 Description

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

Configuration snippets and server snippets pose critical risks (as documented [here](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations-risk)) and Ingress Nginx has disabled them by default as explained in [this page](https://docs.nginx.com/nginx-ingress-controller/configuration/ingress-resources/advanced-configuration-with-snippets/#disadvantages-of-snippets). Enabling them in shared clusters is also impossible and discouraged.

So, this pull request modifies the ingress-nginx manifest template to be safer and more Kubernetes-native by using rewrite-rules and discarding the rest of the unnecessary configurations.


## ✅ Checks

<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
None